### PR TITLE
return empty array if str.match return null

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ function Xray(html, filters) {
         return formatter;
       })
 
-      var m = str.match(rselector);
+      var m = str.match(rselector) || [];
       m.filters = formatters;
       return m;
     }


### PR DESCRIPTION
related to issue #3. An empty rule make x-ray-select crash. This fix avoid the crash (and skip the empty rule then).