### PR TITLE
Allow more customization.

### DIFF
--- a/test/arrays.js
+++ b/test/arrays.js
@@ -130,7 +130,7 @@ describe('arrays selectors', function() {
         <a href="http://lapwinglabs.com">lapwing labs</a>
         <a href="mailto:matt@lapwinglabs.com">
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     assert.deepEqual(xray(['header a[href] | href']), [
       "github.com/matthewmueller",
@@ -154,7 +154,7 @@ describe('arrays selectors', function() {
           <a href="http://mat.io">mat.io</a>
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var arr = xray([{
       $root: '.item',
@@ -194,7 +194,7 @@ describe('arrays selectors', function() {
           <img src="matt.png" />
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var arr = xray([{
       $root: '.item',
@@ -236,7 +236,7 @@ describe('arrays selectors', function() {
           <img src="twitter.png" />
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var arr = xray([{
       $root: '.item',
@@ -290,7 +290,7 @@ describe('arrays selectors', function() {
           </ul>
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var arr = xray([{
       $root: '.item',
@@ -361,7 +361,7 @@ describe('arrays selectors', function() {
           </ul>
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var arr = xray([{
       link: 'a[href]',

--- a/test/objects.js
+++ b/test/objects.js
@@ -79,7 +79,7 @@ describe('objects selectors', function() {
           </ul>
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var obj = xray({
       $root: '.item',
@@ -123,7 +123,7 @@ describe('objects selectors', function() {
           </ul>
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var obj = xray({
       link: 'a[href]',
@@ -158,7 +158,7 @@ describe('objects selectors', function() {
           <a href="https://github.com/matthewmueller">github</a>
         </div>
       </header>
-    */}), filters);
+    */}), { filters: filters });
 
     var obj = xray({
       $root: '.item',

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,52 @@
+/**
+ * Module Dependencies
+ */
+
+var filters = require('./fixtures/filters');
+var assert = require('assert');
+var Xray = require('..');
+var fs = require('fs');
+
+/**
+ * Options
+ */
+
+describe('options', function() {
+  it('should support custom filters', function() {
+    var xray = Xray('<a href="mat.io"></a>', { filters: filters });
+    assert('MAT.IO' == xray('a[href] | uppercase'));
+  });
+
+  it('should support custom filter separator', function() {
+    var xray = Xray('<a href="http://mat.io"></a>', { filters: filters, rfilters: /\s*%\s*/ });
+    assert('MAT.IO' == xray('a[href] % href % uppercase'));
+  });
+
+  it('should support custom attribute selector', function() {
+    var xray = Xray('<a href="http://mat.io"></a>', { filters: filters, rselector: /([^\{]+)?(?:\{([^\{]+)\})?/ });
+    assert('http://mat.io' == xray('a{href}'));
+  });
+
+  it('should support selectorHandler callback', function() {
+    var xray = Xray('<a href="http://mat.io"></a>', { 
+      filters: filters,
+      selectorHandler: function(el, sel, opts) {
+        if(sel.fselector == 'mytag') sel.content = 'example';
+        return sel;
+      }
+    });
+    var obj = xray({ tag: 'mytag', normal: 'a[href] | href' });
+    assert.deepEqual(obj, { tag: 'example', normal: 'mat.io' });
+  });
+
+  it('should support objectHandler callback', function() {
+    var xray = Xray('<a href="http://mat.io"></a>', { 
+      filters: filters,
+      objectHandler: function(el, obj, opts) {
+        return { obj: obj, content: (obj.$tag ? obj.$tag : undefined) };
+      }
+    });
+    var obj = xray({ custom: { $tag: 'mytag' }, normal: 'a[href] | href' });
+    assert.deepEqual(obj, { custom: 'mytag', normal: 'mat.io' });
+  });
+})

--- a/test/strings.js
+++ b/test/strings.js
@@ -31,17 +31,17 @@ describe('strings selectors', function() {
   });
 
   it('should support filters', function() {
-    var xray = Xray('<a href="https://mat.io"></a>', filters);
+    var xray = Xray('<a href="https://mat.io"></a>', { filters: filters });
     assert('mat.io' == xray('a[href]|href'));
   });
 
   it('should support multiple filters', function() {
-    var xray = Xray('<a href="https://mat.io"></a>', filters);
+    var xray = Xray('<a href="https://mat.io"></a>', { filters: filters });
     assert('MAT.IO' == xray('a[href]|href|uppercase'));
   });
 
   it('should support filters with arguments', function() {
-    var xray = Xray('<a href="https://mat.io/rss"></a>', filters);
+    var xray = Xray('<a href="https://mat.io/rss"></a>', { filters: filters });
     assert.deepEqual(['mat.io', 'rss'], xray('a[href]|href|split:/'));
   })
 
@@ -51,7 +51,7 @@ describe('strings selectors', function() {
   })
 
   it('should support falsy values from filters', function() {
-    var xray = Xray('<a href="http://mat.io"></a>', filters);
+    var xray = Xray('<a href="http://mat.io"></a>', { filters: filters });
     assert(false === xray('a[href]|secure'));
   })
 })


### PR DESCRIPTION
Add object options parameter to allow more customization:

`rselector` - modify attribute selector regexp, `{}`, `[]`, `->`  anything you want
`rfilters` - modify filter separator regexp
`filters` - own filters
`selectorHandler` - called before selector processing, allow to use own variables etc.
`objectHandler` - called before object processing, possibility of own keywords like current `$root`

Before:

``` javascript
var filters = {};
select(struct, filters);
```

After (defalt options):

``` javascript
var options = {
  rselector: /([^\[]+)?(?:\[([^\[]+)\])?/,
  rfilters: /\s*\|\s*/,
  filters: {},
  selectorHandler: function(element, selector, options, xray) {
    // you can modify selector or set content directly via selector.content 
    return selector;
  },
  objectHandler: function(element, obj, options, xray) {
    // you can modify obj variable or 
    // you can set the output directly if you return the object { content: <yourcontent> }
    return { obj: obj }
  }
};
select(struct, options);
```
